### PR TITLE
BE-2118 Fix deprecated class method usage

### DIFF
--- a/main.rb
+++ b/main.rb
@@ -156,7 +156,7 @@ else
   options[:xcode_build_dir] = "#{options[:xcode_build_dir]}/Debug-iphonesimulator"
 end
 
-target = Dir["#{options[:xcode_build_dir]}/*.app"].select{ |f| File.exists? f }.map{ |f| File.absolute_path f }[0]
+target = Dir["#{options[:xcode_build_dir]}/*.app"].select{ |f| File.exist? f }.map{ |f| File.absolute_path f }[0]
 move_command = "mv \"#{target}\" \"#{ac_simulator_app_path}\""
 runCommand(move_command)
 


### PR DESCRIPTION
```bash
bsh ❯ rubocop --only Lint/DeprecatedClassMethods main.rb -a
Inspecting 1 file
W

Offenses:

main.rb:159:64: W: [Corrected] Lint/DeprecatedClassMethods: File.exists? is deprecated in favor of File.exist?.
target = Dir["#{options[:xcode_build_dir]}/*.app"].select{ |f| File.exists? f }.map{ |f| File.absolute_path f }[0]
                                                               ^^^^^^^^^^^^

1 file inspected, 1 offense detected, 1 offense corrected
```

It fixes the below pipeline error:
- [master-onur_UnitySample.ipa-build-logs-1708332439708.txt](https://github.com/appcircleio/appcircle-ios-build-simulator/files/14328968/master-onur_UnitySample.ipa-build-logs-1708332439708.txt)

:information_source: See here for more details about the deprecated method:
- https://github.com/beefproject/beef/issues/2739
